### PR TITLE
Started some work on the new grammar system.

### DIFF
--- a/etc/meta-grammar-notes-2.md
+++ b/etc/meta-grammar-notes-2.md
@@ -1,0 +1,239 @@
+# MetaForma Grammar Notes
+
+## Statement and Expression
+
+The two basic units of the grammar are `Statement` and `Expression`.
+
+
+* `Statement` shall be one of the following:
+  * A simple expression, followed by a semicolon
+  * A simple expression that does not need a semicolon
+  * A complex expression, using `Statement` recursively
+* `Expression` shall be one of the following:
+  * A simple expression
+  * A complex expression, using `Expression` recursively
+
+The types of simple and compound expressions comprising `Statement` and
+`Expression` should be the same &mdash; the only reason `Statement` and
+`Expression` are separate is to allow or disallow the use of semicolons in
+various parts of the grammar.
+
+### Complex Statements and Expressions
+
+The compound form of `Statement`, referred to as `Statements`, is designed to be
+similar to a C-like statement list.  Because `Statement` is already
+semicolon-terminated where necessary, `Statements` is simply defined as:
+
+```
+Statements:
+  Statements Statement
+  Statement
+```
+
+The compound form of `Expression`, referred to as `Expressions`, is a
+comma-separated list of expressions, with an optional trailing comma (which is
+useful for cases where each item is on its own line).  `Expressions` is defined
+as:
+
+```
+ExpressionsPart:
+  Expressions "," Expression
+  Expression
+
+Expressions:
+  ExpressionsPart ","
+  ExpressionsPart
+```
+
+Both of these compound forms by themselves match a minimum of one statement or
+expression.  For cases where an empty list should also be matched, the following
+optional forms are defined:
+
+```
+StatementsOpt:
+  Statements
+  %empty
+
+ExpressionsOpt:
+  Expressions
+  ","
+  %empty
+```
+
+## Types of Expression
+
+### Value Expressions
+
+* `Literal`
+
+### Complex Value Expressions
+
+* `Member`
+* `Call`
+* `Index`
+
+#### `Member`
+
+```
+MemberLHS:
+  Identifier
+
+MemberRHS:
+  Identifier
+
+MemberExpression:
+  MemberLHS "." MemberRHS
+```
+
+#### `Call`
+
+```
+CallRHS:
+  "(" ArgumentListOpt ")"
+
+CallExpression:
+  MemberLHS CallRHS
+```
+
+#### `Index`
+
+```
+IndexRHS:
+  "[" ArgumentList "]"
+
+IndexExpression:
+  MemberLHS IndexRHS
+```
+
+### Value Assignment
+
+```
+AssignLHS:
+  MemberExpression
+  CallExpression
+  IndexExpression
+
+AssignRHS:
+  RValue
+  AssignExpression
+
+RValue: ...good question.
+
+AssignOp - any of:
+  "=" "||=" "&&=" "|=" "&=" "^=" "+=" "-=" "*=" "/=" "%="
+
+AssignExpression:
+  AssignLHS AssignOp AssignRHS
+```
+
+###  Chaining Calls/Assignments
+
+* `Cascade`
+  * `Member`: ex. `foo..bar`
+  * `Call`: ex. `foo..()`
+  * `Index`: ex. `foo..[0]`
+  * `Assignment`: ex. `foo..bar = 5..() = 5..[0] = 5`
+
+```
+CascadeLHS:
+  MemberLHS
+  CascadeExpression
+
+CascadeRHS:
+  MemberRHS
+  CallRHS
+  IndexRHS
+
+CascadeExpression:
+  CascadeLHS ".." CascadeRHS
+```
+
+### Conditional Expressions
+
+* `If` / `Unless`
+* `IfElse` / `UnlessElse`
+
+```
+LetCondition:
+  LetExpression ";" Expression
+
+Condition:
+  Expression
+  LetCondition
+
+ParenCondition:
+  "(" Condition ")"
+
+IfExpression:
+  "if" ParenCondition Expression
+
+IfElseExpression:
+  "if" ParenCondition Expression "else" Expression
+
+UnlessExpression:
+  "unless" ParenCondition Expression
+
+UnlessElseExpression:
+  "unless" ParenCondition Expression "else" Expression
+```
+
+### Loop Expressions
+
+* `Loop`
+* `While` / `Until`
+* `DoWhile` / `DoUntil`
+* `For`
+
+```
+LoopExpression:
+  "loop" Statement
+
+WhilePreamble:
+  "while" ParenCondition
+
+UntilPreamble:
+  "until" ParenCondition
+
+ForPreamble:
+  "for" "(" LetCondition ";" Expression ")"
+
+DoPreamble:
+  "do"
+  "do" "(" LetExpression ")"
+
+DoExpression:
+  DoPreamble Expression
+
+WhileExpression:
+  WhilePreamble Expression
+
+DoWhileExpression:
+  DoExpression WhilePreamble
+
+UntilExpression:
+  UntilPreamble Expression
+
+DoUntilExpression:
+  DoExpression UntilPreamble
+
+ForExpression:
+  ForPreamble Expression
+```
+
+### Error Handling
+
+* `Try`
+* `Catch`
+* `Else`
+  * *`try...else try` chaining?*
+* `Finally`
+
+### Pattern Matching
+
+* `Switch`
+
+### Object Expressions
+
+* `Struct`
+* `Function`
+* `Record`

--- a/scripts/astgen/loosehash.rb
+++ b/scripts/astgen/loosehash.rb
@@ -73,6 +73,26 @@ class ErrorableHash
 
   def values; @hash.values end
 
+  def rehash
+    new_hash = {}
+
+    key_set = Set.new
+    conflicts = Set.new
+
+    @hash.each do |key, val|
+      if new_hash.has_key?(key) && !new_hash[key].eql?(val)
+        yield(key, val) if conflicts.add?(key) && block_given?
+      else
+        new_hash[key] = val
+      end
+    end
+
+    @hash = new_hash
+    @errors = Set.new(@errors)
+
+    conflicts.each{|k| make_error(k) }
+  end
+
   def table; @hash.clone end
   def errors; @errors.clone end
 

--- a/scripts/astgen/node.rb
+++ b/scripts/astgen/node.rb
@@ -297,6 +297,7 @@ module ASTGen
       :alt_formats,
       :format,
       :format_syms,
+      :unused,
     )
 
     def initialize(name, d)
@@ -315,6 +316,7 @@ module ASTGen
       @alt_formats = {}
       @format = {}
       @format_syms = []
+      @unused = false
     end
 
     @@Namespace = "frma"
@@ -324,31 +326,33 @@ module ASTGen
     @@SymMembName = "sym"
     @@SymNoneName = "_None"
 
+    @@ClassNamePrefixes = [
+      ["M", /^meta/i],
+      ["X", /(?<!(?:^|^meta))expression$/i],
+      ["S", /(?<!(?:^|^meta))statement$/i],
+    ]
+
+    @@ClassNameAbbrs = [
+      ["Argument", "Arg"],
+      ["Expression", "Expr"],
+      ["Function", "Func"],
+      ["Primary", "Prim", "Primaries"],
+      ["Statement", "Stmt"],
+    ]
+
     def self.Namespace; @@Namespace end
 
     def self.class_name(name)
-      "F#{[
-        *("M" if name =~ /^meta/i),
-        *("X" if name =~ /(?<!(?:^|^meta))expression$/i)
-      ].join}#{[
-        ["Argument", "Arg"],
-        ["Expression", "Expr"],
-        ["Function", "Func"],
-        ["Primary", "Prim", "Primaries"],
-        ["Statement", "Stmt"],
-      ].reduce(name.to_s.gsub(/(?:^meta|(?<!(?:^|^meta))expression$)/i, "")) do |str, (from, to, from_plur, to_plur)|
-        if from_plur
-          str
-            .gsub(/#{from}(?!\p{Ll})/, "#{to}\\1")
-            .gsub(/#{from_plur}(?!\p{Ll})/, "#{to_plur || "#{to}s"}")
-        else
-          str.gsub(/#{from}(s)?(?!\p{Ll})/, "#{to}\\1")
-        end
-        # .gsub(/Argument(s)?(?!\p{Ll})/, %q{Arg\1})
-        # .gsub(/Expression(?!\p{Ll})/, "Expr")
-        # .gsub(/Function(?!\p{Ll})/, "Func")
-        # .gsub(/Primaries(?!\p{Ll})/, "Prims")
-        # .gsub(/Primary(?!\p{Ll})/, "Prim")
+      "F#{@@ClassNamePrefixes.map{|p, r| p if name =~ r }.join}#{@@ClassNameAbbrs.reduce(
+          @@ClassNamePrefixes.reduce(name.to_s) {|s, (_, r)| s.gsub(r, "") }
+        ) do |str, (from, to, from_plur, to_plur)|
+          if from_plur
+            str
+              .gsub(/#{from}(?!\p{Ll})/, "#{to}")
+              .gsub(/#{from_plur}(?!\p{Ll})/, "#{to_plur || "#{to}s"}")
+          else
+            str.gsub(/#{from}(s)?(?!\p{Ll})/, "#{to}\\1")
+          end
         end.to_sym}"
     end
     def self.qual_class_name(name) "#{@@Namespace}::#{class_name(name)}" end


### PR DESCRIPTION
ASTGen can now detect and elide symbols that only alias other symbols, as well as recursively elide any symbols (and rules that contain such symbols) that have no rules defined and are considered unmatchable.  (If you look at the number of inline `if` statements removed from `ast-test.rb`, you'll understand why.)